### PR TITLE
Fix a 'missing separator' error during compiling of TensorLAC.

### DIFF
--- a/TensorLAC/Makefile
+++ b/TensorLAC/Makefile
@@ -26,7 +26,7 @@
 
 
 all: TensorLAC.cu
- 	nvcc -o TensorLAC -arch=sm_75 TensorLAC.cu
+	nvcc -o TensorLAC -arch=sm_75 TensorLAC.cu
 
 clean:
 	rm -f TensorLAC


### PR DESCRIPTION
There was a space mixed with a tab in TensorLAC's Makefile that wouldn't allow compilation.